### PR TITLE
Add basic signal support & test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "axsignal"
+version = "0.1.0"
+dependencies = [
+ "axconfig",
+ "axerrno",
+ "axhal",
+ "axtask",
+ "bitflags 2.9.0",
+ "linux-raw-sys",
+ "log",
+]
+
+[[package]]
 name = "axsync"
 version = "0.1.0"
 dependencies = [
@@ -1180,6 +1193,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "starry"
 version = "0.1.0"
 dependencies = [
+ "axconfig",
  "axerrno",
  "axfeat",
  "axfs",
@@ -1211,12 +1225,14 @@ dependencies = [
  "axnet",
  "axns",
  "axprocess",
+ "axsignal",
  "axsync",
  "axtask",
  "bitflags 2.9.0",
  "cfg-if",
  "ctor_bare",
  "flatten_objects",
+ "linkme",
  "linux-raw-sys",
  "macro_rules_attribute",
  "memory_addr",
@@ -1238,6 +1254,7 @@ dependencies = [
  "axmm",
  "axns",
  "axprocess",
+ "axsignal",
  "axsync",
  "axtask",
  "crate_interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
+source = "git+https://github.com/Starry-OS/axsignal.git#e9613e8c9c9e55df9a5de2ee61dcfe754ddb85f5"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 [[package]]
 name = "axprocess"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axprocess.git#f16a5a1909688054b9fb33d3092f6f5f06bcca29"
+source = "git+https://github.com/Starry-OS/axprocess.git#02cffaf868aac9eca78a5a7feea71a74ed691b3e"
 dependencies = [
  "kspin",
  "weak-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ axsync = { git = "https://github.com/oscomp/arceos.git" }
 axtask = { git = "https://github.com/oscomp/arceos.git" }
 
 axprocess = { git = "https://github.com/Starry-OS/axprocess.git" }
+axsignal = { git = "https://github.com/Starry-OS/axsignal.git" }
 
 axerrno = "0.1"
 bitflags = "2.6"
@@ -74,6 +75,7 @@ axlog.workspace = true
 axruntime.workspace = true
 axsync.workspace = true
 axtask.workspace = true
+axconfig.workspace = true
 
 axprocess.workspace = true
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,6 +20,7 @@ axsync.workspace = true
 axtask.workspace = true
 
 axprocess.workspace = true
+axsignal.workspace = true
 
 axerrno.workspace = true
 bitflags.workspace = true
@@ -35,6 +36,7 @@ ctor_bare = "0.2.1"
 flatten_objects = "0.2.3"
 macro_rules_attribute = "0.2"
 num_enum = { version = "0.7", default-features = false }
+linkme.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86 = "0.52"

--- a/api/src/imp/signal.rs
+++ b/api/src/imp/signal.rs
@@ -1,25 +1,330 @@
-use core::ffi::c_void;
+use core::{mem, time::Duration};
 
-use axerrno::LinuxResult;
+use axerrno::{LinuxError, LinuxResult};
+use axhal::{
+    arch::TrapFrame,
+    trap::{POST_TRAP, register_trap_handler},
+};
+use axprocess::{Pid, Process, ProcessGroup};
+use axsignal::{
+    ctypes::{k_sigaction, SignalInfo, SignalSet}, handle_signal, PendingSignals, SignalOSAction
+};
+use axtask::{TaskExtRef, current};
+use linux_raw_sys::general::{siginfo, timespec};
+use starry_core::task::{ProcessData, get_process, get_process_group};
 
-use crate::ptr::{UserConstPtr, UserPtr};
+use crate::ptr::{UserConstPtr, UserPtr, nullable};
+
+use super::do_exit;
+
+const SIGKILL: u32 = 9;
+const SIGSTOP: u32 = 19;
+
+fn dequeue_signal(mask: &SignalSet) -> Option<SignalInfo> {
+    let curr = current();
+    let task_ext = curr.task_ext();
+    task_ext
+        .thread_data()
+        .pending
+        .lock()
+        .dequeue_signal(mask)
+        .or_else(|| task_ext.process_data().pending.lock().dequeue_signal(mask))
+}
+fn check_signals(tf: &mut TrapFrame, restore_blocked: Option<SignalSet>) -> bool {
+    let curr = current();
+    let task_ext = curr.task_ext();
+
+    let actions = task_ext.process_data().signal_actions.lock();
+
+    let blocked = task_ext.thread_data().blocked.lock();
+    let mask = !*blocked;
+    let restore_blocked = restore_blocked.unwrap_or_else(|| *blocked);
+    drop(blocked);
+
+    let (signo, os_action) = loop {
+        let Some(sig) = dequeue_signal(&mask) else {
+            return false;
+        };
+        let signo = sig.signo();
+        let action = &actions[signo as usize];
+        if let Some(os_action) = handle_signal(tf, restore_blocked, sig, action) {
+            break (signo, os_action);
+        }
+    };
+    drop(actions);
+
+    match os_action {
+        SignalOSAction::Terminate => {
+            do_exit(128 + signo as i32, true);
+        }
+        SignalOSAction::CoreDump => {
+            // TODO: implement core dump
+            do_exit(128 + signo as i32, true);
+        }
+        SignalOSAction::Stop => {
+            // TODO: implement stop
+            do_exit(1, true);
+        }
+        SignalOSAction::Continue => {
+            // TODO: implement continue
+        }
+        SignalOSAction::Handler { add_blocked } => {
+            task_ext
+                .thread_data()
+                .blocked
+                .lock()
+                .add_from(&add_blocked);
+        }
+    }
+    true
+}
+
+#[register_trap_handler(POST_TRAP)]
+fn post_trap_callback(tf: &mut TrapFrame, from_user: bool) {
+    if !from_user {
+        return;
+    }
+
+    check_signals(tf, None);
+}
+
+fn check_sigset_size(size: usize) -> LinuxResult<()> {
+    if size != size_of::<SignalSet>() {
+        return Err(LinuxError::EINVAL);
+    }
+    Ok(())
+}
 
 pub fn sys_rt_sigprocmask(
-    _how: i32,
-    _set: UserConstPtr<c_void>,
-    _oldset: UserPtr<c_void>,
-    _sigsetsize: usize,
+    how: i32,
+    set: UserConstPtr<SignalSet>,
+    oldset: UserPtr<SignalSet>,
+    sigsetsize: usize,
 ) -> LinuxResult<isize> {
-    warn!("sys_rt_sigprocmask: not implemented");
+    check_sigset_size(sigsetsize)?;
+
+    let curr = current();
+    let mut blocked = curr.task_ext().thread_data().blocked.lock();
+
+    if let Some(oldset) = nullable!(oldset.get_as_mut())? {
+        *oldset = *blocked;
+    }
+
+    if let Some(set) = nullable!(set.get_as_ref())? {
+        match how {
+            // SIG_BLOCK
+            0 => blocked.add_from(set),
+            // SIG_UNBLOCK
+            1 => blocked.remove_from(set),
+            // SIG_SETMASK
+            2 => *blocked = *set,
+            _ => return Err(LinuxError::EINVAL),
+        }
+    }
+
     Ok(0)
 }
 
 pub fn sys_rt_sigaction(
-    _signum: i32,
-    _act: UserConstPtr<c_void>,
-    _oldact: UserPtr<c_void>,
-    _sigsetsize: usize,
+    signum: i32,
+    act: UserConstPtr<k_sigaction>,
+    oldact: UserPtr<k_sigaction>,
+    sigsetsize: usize,
 ) -> LinuxResult<isize> {
-    warn!("sys_rt_sigaction: not implemented");
+    check_sigset_size(sigsetsize)?;
+
+    let signum = signum as u32;
+    if !(1..32).contains(&signum) {
+        return Err(LinuxError::EINVAL);
+    }
+    if signum == SIGKILL || signum == SIGSTOP {
+        return Err(LinuxError::EINVAL);
+    }
+
+    let curr = current();
+    let mut actions = curr.task_ext().process_data().signal_actions.lock();
+
+    if let Some(oldact) = nullable!(oldact.get_as_mut())? {
+        actions[signum as usize].to_ctype(oldact);
+    }
+
+    if let Some(act) = nullable!(act.get_as_ref())? {
+        actions[signum as usize] = (*act).try_into()?;
+    }
+
     Ok(0)
+}
+
+pub fn sys_rt_sigpending(set: UserPtr<SignalSet>, sigsetsize: usize) -> LinuxResult<isize> {
+    check_sigset_size(sigsetsize)?;
+
+    let curr = current();
+    let thr_pending = curr.task_ext().thread_data().pending.lock();
+    let proc_pending = curr.task_ext().process_data().pending.lock();
+
+    *set.get_as_mut()? = thr_pending.pending | proc_pending.pending;
+
+    Ok(0)
+}
+
+pub fn sys_rt_sigreturn(tf: &mut TrapFrame) -> LinuxResult<()> {
+    let curr = current();
+    let mut thr_sigman = curr.task_ext().thread_data().pending.lock();
+    let mut blocked = curr.task_ext().thread_data().blocked.lock();
+    thr_sigman.restore(tf, &mut blocked);
+    Ok(())
+}
+
+pub fn sys_rt_sigtimedwait(
+    set: UserConstPtr<SignalSet>,
+    info: UserPtr<siginfo>,
+    timeout: UserConstPtr<timespec>,
+    sigsetsize: usize,
+) -> LinuxResult<isize> {
+    check_sigset_size(sigsetsize)?;
+
+    let curr = current();
+    let thr_data = curr.task_ext().thread_data();
+    let mut set = *set.get_as_ref()?;
+    // Non-blocked signals cannot be waited
+    set.remove_from(&!*thr_data.blocked.lock());
+
+    let timeout = nullable!(timeout.get_as_ref())?
+        .map(|spec| Duration::new(spec.tv_sec as u64, spec.tv_nsec as u32));
+
+    if let Some(siginfo) = thr_data.pending.lock().dequeue_signal(&set) {
+        if let Some(info) = nullable!(info.get_as_mut())? {
+            siginfo.to_ctype(info);
+        }
+        return Ok(0);
+    }
+
+    let wq = curr.task_ext().process_data().signal_wq.clone();
+
+    let deadline = timeout.map(|dur| axhal::time::wall_time() + dur);
+
+    // There might be false wakeups, so we need a loop
+    loop {
+        match &deadline {
+            Some(deadline) => {
+                match deadline.checked_sub(axhal::time::wall_time()) {
+                    Some(dur) => {
+                        if wq.wait_timeout(dur) {
+                            // timed out
+                            break;
+                        }
+                    }
+                    None => {
+                        // deadline passed
+                        break;
+                    }
+                }
+            }
+            _ => wq.wait(),
+        }
+
+        if let Some(signal) = dequeue_signal(&set) {
+            if let Some(info) = nullable!(info.get_as_mut())? {
+                signal.to_ctype(info);
+            }
+            return Ok(0);
+        }
+    }
+
+    // TODO: EINTR
+
+    Err(LinuxError::EAGAIN)
+}
+
+pub fn sys_rt_sigsuspend(
+    tf: &mut TrapFrame,
+    set: UserPtr<SignalSet>,
+    sigsetsize: usize,
+) -> LinuxResult<()> {
+    check_sigset_size(sigsetsize)?;
+
+    let curr = current();
+    let thr_data = curr.task_ext().thread_data();
+    let set = set.get_as_mut()?;
+
+    set.remove(SIGKILL);
+    set.remove(SIGSTOP);
+
+    let old_blocked = mem::replace(&mut *thr_data.blocked.lock(), *set);
+
+    // We need to pretend that we returned from the syscall
+    #[cfg(any(
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+        target_arch = "loongarch64"
+    ))]
+    tf.set_ip(tf.ip() + 4);
+    tf.set_retval((-LinuxError::EINTR.code() as isize) as usize);
+
+    loop {
+        if check_signals(tf, Some(old_blocked)) {
+            break;
+        }
+        curr.task_ext().process_data().signal_wq.wait();
+    }
+
+    Ok(())
+}
+
+fn send_signal_process(proc: &Process, sig: SignalInfo) {
+    info!("Send signal {} to process {}", sig.signo(), proc.pid());
+    let proc_data: &ProcessData = proc.data().unwrap();
+    proc_data.pending.lock().send_signal(sig);
+    proc_data.signal_wq.notify_one(false);
+}
+fn send_signal_process_group(pg: &ProcessGroup, sig: SignalInfo) -> usize {
+    info!("Send signal {} to process group {}", sig.signo(), pg.pgid());
+    let processes = pg.processes();
+    for proc in pg.processes() {
+        send_signal_process(&proc, sig.clone());
+    }
+    processes.len()
+}
+
+pub fn sys_kill(pid: i32, sig: i32) -> LinuxResult<isize> {
+    if !(1..32).contains(&sig) {
+        return Err(LinuxError::EINVAL);
+    }
+    if sig == 0 {
+        // TODO: should also check permissions
+        return Ok(0);
+    }
+
+    let sig = SignalInfo::new(sig as u32, SignalInfo::SI_USER);
+
+    let curr = current();
+    let mut result = 0usize;
+    match pid {
+        1.. => {
+            let proc = get_process(pid as Pid)?;
+            send_signal_process(&proc, sig);
+            result += 1;
+        }
+        0 => {
+            let pg = curr.task_ext().thread.process().group();
+            result += send_signal_process_group(&pg, sig);
+        }
+        -1 => {
+            // TODO: this should "send signal to every process for which the
+            // calling process has permission to send signals, except for
+            // process 1"
+            // let mut guard = curr.task_ext().signal.lock();
+            // for child in curr.task_ext().children.lock().iter() {
+            // result += child.task_ext().signal.lock().send_signal(sig.clone()) as isize;
+            // }
+            // result += guard.send_signal(sig) as isize;
+            todo!()
+        }
+        ..-1 => {
+            let pg = get_process_group(pid as Pid)?;
+            result += send_signal_process_group(&pg, sig);
+        }
+    }
+
+    Ok(result as isize)
 }

--- a/api/src/imp/signal.rs
+++ b/api/src/imp/signal.rs
@@ -344,12 +344,3 @@ pub fn sys_tgkill(tgid: Pid, tid: Pid, sig: u32) -> LinuxResult<isize> {
     send_signal_thread(&thr, sig);
     Ok(0)
 }
-
-pub fn sys_rt_sigtimedwait(
-    _set: UserConstPtr<c_void>,
-    _info: UserPtr<c_void>,
-    _timeout: UserConstPtr<c_void>,
-) -> LinuxResult<isize> {
-    warn!("sys_rt_sigtimedwait: not implemented");
-    Ok(0)
-}

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -1,6 +1,8 @@
+use axsignal::ctypes::SignalInfo;
 use axtask::{TaskExtRef, current};
+use linux_raw_sys::general::{SI_KERNEL, SIGKILL};
 
-use crate::fd::FD_TABLE;
+use crate::{fd::FD_TABLE, send_signal_thread};
 
 pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     let curr = current();
@@ -25,7 +27,10 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     }
     if group_exit {
         process.group_exit();
-        // TODO: send SIGKILL to other threads
+        let sig = SignalInfo::new(SIGKILL, SI_KERNEL);
+        for thr in process.threads() {
+            send_signal_thread(&*thr, sig.clone());
+        }
     }
     axtask::exit(exit_code)
 }

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -30,7 +30,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
         process.group_exit();
         let sig = SignalInfo::new(SIGKILL, SI_KERNEL);
         for thr in process.threads() {
-            send_signal_thread(&*thr, sig.clone());
+            send_signal_thread(&thr, sig.clone());
         }
     }
     axtask::exit(exit_code)

--- a/apps/libc/c/signal/signal.c
+++ b/apps/libc/c/signal/signal.c
@@ -1,0 +1,173 @@
+#include <errno.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void test_term() {
+  if (fork() == 0) {
+    kill(getpid(), SIGTERM);
+    while (1)
+      ;
+  }
+  wait(NULL);
+  puts("test_term ok");
+}
+
+static void signal_handler(int signum) {
+  static int count = 0;
+  count++;
+  printf("Received signal %d, count=%d\n", signum, count);
+  if (count > 1) {
+    return;
+  }
+  // This should be blocked and won't cause recursion
+  kill(0, SIGTERM);
+  printf("End, count=%d\n", count);
+}
+
+void test_sigaction() {
+  struct sigaction sa = {0};
+  sa.sa_handler = signal_handler;
+  sigaction(SIGTERM, &sa, NULL);
+  kill(0, SIGTERM);
+  puts("test_sigaction ok1");
+
+  sa.sa_handler = (void (*)(int))1;
+  sigaction(SIGTERM, &sa, NULL);
+  kill(0, SIGTERM);
+  puts("test_sigaction ok2");
+
+  sa.sa_handler = (void (*)(int))0;
+  sigaction(SIGTERM, &sa, NULL);
+}
+
+void test_sigprocmask() {
+  sigset_t set, set2;
+  sigemptyset(&set);
+  sigaddset(&set, SIGTERM);
+  sigprocmask(SIG_BLOCK, &set, NULL);
+  kill(0, SIGTERM);
+
+  sigpending(&set2);
+  if (sigismember(&set2, SIGTERM)) {
+    puts("test_sigprocmask ok1");
+  }
+
+  // Ignore SIGTERM for once
+  struct sigaction sa = {0};
+  sa.sa_handler = (void (*)(int))1;
+  sigaction(SIGTERM, &sa, NULL);
+
+  sigdelset(&set, SIGTERM);
+  sigprocmask(SIG_SETMASK, &set, NULL);
+
+  sigpending(&set2);
+  if (!sigismember(&set2, SIGTERM)) {
+    puts("test_sigprocmask ok2");
+  }
+
+  sa.sa_handler = (void (*)(int))0;
+  sigaction(SIGTERM, &sa, NULL);
+}
+
+void test_sigkill_stop() {
+  struct sigaction sa = {0};
+  sa.sa_handler = signal_handler;
+  if (sigaction(SIGKILL, &sa, NULL) < 0) {
+    puts("test_sigkill_stop ok1");
+  }
+  if (sigaction(SIGSTOP, &sa, NULL) < 0) {
+    puts("test_sigkill_stop ok2");
+  }
+}
+
+void test_sigwait() {
+  int pid = fork();
+  if (pid == 0) {
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+    int sig;
+    sigwait(&set, &sig);
+    if (sig == SIGTERM) {
+      puts("test_sigwait ok1");
+    }
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM);
+  wait(NULL);
+  puts("test_sigwait ok2");
+
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGTERM);
+  sigprocmask(SIG_BLOCK, &set, NULL);
+  struct timespec ts = {1, 0};
+  if (sigtimedwait(&set, NULL, &ts) < 0 && errno == EAGAIN) {
+    puts("test_sigwait ok3");
+  }
+  sigprocmask(SIG_UNBLOCK, &set, NULL);
+}
+
+static void signal_handler2(int signum) { puts("test_sigsuspend ok1"); }
+static void signal_handler3(int signum) { puts("test_sigsuspend ok3"); }
+void test_sigsuspend() {
+  int pid = fork();
+  if (pid == 0) {
+    struct sigaction sa = {0};
+    sa.sa_handler = signal_handler2;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    sigsuspend(&set);
+    // SIGTERM is handled immediately after so this won't run
+    // To ensure it, we check this return code below
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM);
+  sleep(1);
+  kill(pid, SIGUSR1);
+  int status;
+  wait(&status);
+  if (status != 0) {
+    puts("test_sigsuspend ok2");
+  }
+
+  pid = fork();
+  if (pid == 0) {
+    // Ignore SIGTERM
+    struct sigaction sa = {0};
+    sa.sa_handler = (void (*)(int))1;
+    sigaction(SIGTERM, &sa, NULL);
+
+    sa.sa_handler = signal_handler3;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigsuspend(&set);
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM); // SIGTERM is ignored so sigsuspend won't unblock
+  sleep(1);
+  kill(pid, SIGUSR1);
+}
+
+int main() {
+  test_term();
+  test_sigaction();
+  test_sigprocmask();
+  test_sigkill_stop();
+  test_sigwait();
+  test_sigsuspend();
+  return 0;
+}

--- a/apps/libc/c/sleep/sleep.c
+++ b/apps/libc/c/sleep/sleep.c
@@ -3,7 +3,7 @@
 int main()
 {
     printf("Sleeping for 5 seconds...\n");
-    sleep(5);
+    sleep(1);
     printf("Done!\n");
     return 0;
 }

--- a/apps/libc/expect_off.out
+++ b/apps/libc/expect_off.out
@@ -5,3 +5,20 @@ log_level = off
 Hello, World!
 Sleeping for 5 seconds...
 Done!
+
+test_term ok
+Received signal 15, count=1
+End, count=1
+Received signal 15, count=2
+test_sigaction ok1
+test_sigaction ok2
+test_sigprocmask ok1
+test_sigprocmask ok2
+test_sigkill_stop ok1
+test_sigkill_stop ok2
+test_sigwait ok1
+test_sigwait ok2
+test_sigwait ok3
+test_sigsuspend ok1
+test_sigsuspend ok2
+test_sigsuspend ok3

--- a/apps/libc/testcase_list
+++ b/apps/libc/testcase_list
@@ -1,2 +1,3 @@
 helloworld_c
 sleep_c
+signal_c

--- a/configs/aarch64.toml
+++ b/configs/aarch64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/dummy.toml
+++ b/configs/dummy.toml
@@ -54,6 +54,8 @@ user-heap-base = 0        # uint
 # The size of the user heap.
 user-heap-size = 0          # uint
 
+# The address of signal trampoline.
+signal-trampoline = 0
 
 #
 # Device specifications

--- a/configs/loongarch64.toml
+++ b/configs/loongarch64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/riscv64.toml
+++ b/configs/riscv64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/x86_64.toml
+++ b/configs/x86_64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ axsync.workspace = true
 axtask.workspace = true
 
 axprocess.workspace = true
+axsignal.workspace = true
 
 axerrno.workspace = true
 linkme.workspace = true

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -271,6 +271,9 @@ pub fn add_thread_to_table(thread: &Arc<Thread>) {
     session_table.insert(session.sid(), &session);
 }
 
+pub fn get_thread(tid: Pid) -> LinuxResult<Arc<Thread>> {
+    THREAD_TABLE.read().get(&tid).ok_or(LinuxError::ESRCH)
+}
 pub fn get_process(pid: Pid) -> LinuxResult<Arc<Process>> {
     PROCESS_TABLE.read().get(&pid).ok_or(LinuxError::ESRCH)
 }
@@ -279,4 +282,7 @@ pub fn get_process_group(pgid: Pid) -> LinuxResult<Arc<ProcessGroup>> {
         .read()
         .get(&pgid)
         .ok_or(LinuxError::ESRCH)
+}
+pub fn get_session(sid: Pid) -> LinuxResult<Arc<Session>> {
+    SESSION_TABLE.read().get(&sid).ok_or(LinuxError::ESRCH)
 }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -9,6 +9,7 @@ use alloc::{
     string::String,
     sync::{Arc, Weak},
 };
+use axerrno::{LinuxError, LinuxResult};
 use axhal::{
     arch::UspaceContext,
     time::{NANOS_PER_MICROS, NANOS_PER_SEC, monotonic_time_nanos},
@@ -16,8 +17,12 @@ use axhal::{
 use axmm::{AddrSpace, kernel_aspace};
 use axns::{AxNamespace, AxNamespaceIf};
 use axprocess::{Pid, Process, ProcessGroup, Session, Thread};
-use axsync::Mutex;
-use axtask::{TaskExtRef, TaskInner, current};
+use axsignal::{
+    PendingSignals,
+    ctypes::{SignalAction, SignalSet},
+};
+use axsync::{Mutex, spin::SpinNoIrq};
+use axtask::{TaskExtRef, TaskInner, WaitQueue, current};
 use memory_addr::VirtAddrRange;
 use spin::{Once, RwLock};
 use weak_map::WeakMap;
@@ -118,6 +123,11 @@ pub struct ThreadData {
     ///
     /// When the thread exits, the kernel clears the word at this address if it is not NULL.
     pub clear_child_tid: AtomicUsize,
+
+    /// The pending signals
+    pub pending: SpinNoIrq<PendingSignals>,
+    /// The set of signals currently blocked from delivery.
+    pub blocked: Mutex<SignalSet>,
 }
 
 impl ThreadData {
@@ -125,6 +135,8 @@ impl ThreadData {
     pub fn new() -> Self {
         Self {
             clear_child_tid: AtomicUsize::new(0),
+            pending: SpinNoIrq::new(PendingSignals::new()),
+            blocked: Mutex::default(),
         }
     }
 
@@ -149,6 +161,16 @@ pub struct ProcessData {
     heap_bottom: AtomicUsize,
     /// The user heap top
     heap_top: AtomicUsize,
+
+    /// The process-level shared pending signals
+    pub pending: SpinNoIrq<PendingSignals>,
+    /// The signal actions
+    pub signal_actions: Mutex<[SignalAction; 32]>,
+    /// The wait queue for signal. Used by `rt_sigtimedwait`, etc.
+    ///
+    /// Note that this is shared by all threads in the process, so false wakeups
+    /// may occur.
+    pub signal_wq: Arc<WaitQueue>,
 }
 
 impl ProcessData {
@@ -159,6 +181,10 @@ impl ProcessData {
             ns: AxNamespace::new_thread_local(),
             heap_bottom: AtomicUsize::new(axconfig::plat::USER_HEAP_BASE),
             heap_top: AtomicUsize::new(axconfig::plat::USER_HEAP_BASE),
+
+            pending: SpinNoIrq::new(PendingSignals::new()),
+            signal_actions: Mutex::default(),
+            signal_wq: Arc::new(WaitQueue::new()),
         }
     }
 
@@ -243,4 +269,14 @@ pub fn add_thread_to_table(thread: &Arc<Thread>) {
         return;
     }
     session_table.insert(session.sid(), &session);
+}
+
+pub fn get_process(pid: Pid) -> LinuxResult<Arc<Process>> {
+    PROCESS_TABLE.read().get(&pid).ok_or(LinuxError::ESRCH)
+}
+pub fn get_process_group(pgid: Pid) -> LinuxResult<Arc<ProcessGroup>> {
+    PROCESS_GROUP_TABLE
+        .read()
+        .get(&pgid)
+        .ok_or(LinuxError::ESRCH)
 }

--- a/scripts/get_deps.sh
+++ b/scripts/get_deps.sh
@@ -3,6 +3,6 @@
 AX_ROOT=.arceos
 
 test ! -d "$AX_ROOT" && echo "Cloning repositories ..." || true
-test ! -d "$AX_ROOT" && git clone https://github.com/oscomp/arceos "$AX_ROOT" --depth=1 || true
+test ! -d "$AX_ROOT" && git clone https://github.com/Starry-OS/arceos "$AX_ROOT" --depth=1 || true
 
 $(dirname $0)/set_ax_root.sh $AX_ROOT

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -132,6 +132,7 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::rt_sigpending => sys_rt_sigpending(tf.arg0().into(), tf.arg1() as _),
         Sysno::rt_sigreturn => sys_rt_sigreturn(tf),
         Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
+        Sysno::tgkill => sys_tgkill(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
         sysno => {
             warn!("Unimplemented syscall: {}", sysno);
             Err(LinuxError::ENOSYS)


### PR DESCRIPTION
# Status

Depends on [arceos#1](https://github.com/Starry-OS/arceos/pull/1).

# Description

This PR adds basic signal support. Currently 32 POSIX standard signals are handled.

- A generic trap handler (`ANY_TRAP`) is registered to handle signals
- `SignalManager` is added to `TaskExt`
- Signal trampoline is mapped to every uspace
- Four related tests are added
- `fork` on x86_64 is implemented to support the tests

Implemented syscalls: `rt_sigprocmask`、`rt_sigaction`、`rt_sigreturn`、`rt_sigpending`、`kill`
